### PR TITLE
Ending a level now return you to the level select

### DIFF
--- a/src/Scenes/Levels/Level0.ts
+++ b/src/Scenes/Levels/Level0.ts
@@ -122,10 +122,10 @@ export default class Level0 extends Level {
     if (this.levelState === 'Ended' || this.levelState === 'Aborted') {
       if (Tanks.levelReached <= 0 && this.levelState === 'Ended') {
         Tanks.levelReached = 1;
-        return new SelectLevel(this.maxX, this.maxY, 1);
       } else if (this.levelState === 'Aborted') {
         return new SelectLevel(this.maxX, this.maxY, 0);
       }
+      return new SelectLevel(this.maxX, this.maxY, 1);
     } else if (this.levelState === 'Restart') {
       return new Level0(this.maxX, this.maxY);
     }

--- a/src/Scenes/Levels/Level1.ts
+++ b/src/Scenes/Levels/Level1.ts
@@ -78,10 +78,10 @@ export default class Level1 extends Level {
     if (this.levelState === 'Ended' || this.levelState === 'Aborted') {
       if (Tanks.levelReached <= 1 && this.levelState === 'Ended') {
         Tanks.levelReached = 2;
-        return new SelectLevel(this.maxX, this.maxY, 1);
       } else if (this.levelState === 'Aborted') {
         return new SelectLevel(this.maxX, this.maxY, 1);
       }
+      return new SelectLevel(this.maxX, this.maxY, 1);
     } else if (this.levelState === 'Restart') {
       return new Level1(this.maxX, this.maxY);
     }

--- a/src/Scenes/Levels/Level2.ts
+++ b/src/Scenes/Levels/Level2.ts
@@ -92,10 +92,10 @@ export default class Level2 extends Level {
     if (this.levelState === 'Ended' || this.levelState === 'Aborted') {
       if (Tanks.levelReached <= 2 && this.levelState === 'Ended') {
         Tanks.levelReached = 3;
-        return new SelectLevel(this.maxX, this.maxY, 1);
       } else if (this.levelState === 'Aborted') {
         return new SelectLevel(this.maxX, this.maxY, 1);
       }
+      return new SelectLevel(this.maxX, this.maxY, 1);
     } else if (this.levelState === 'Restart') {
       return new Level2(this.maxX, this.maxY);
     }

--- a/src/Scenes/Levels/Level3.ts
+++ b/src/Scenes/Levels/Level3.ts
@@ -120,10 +120,10 @@ export default class Level3 extends Level {
     if (this.levelState === 'Ended' || this.levelState === 'Aborted') {
       if (Tanks.levelReached <= 3 && this.levelState === 'Ended') {
         Tanks.levelReached = 4;
-        return new SelectLevel(this.maxX, this.maxY, 1);
       } else if (this.levelState === 'Aborted') {
         return new SelectLevel(this.maxX, this.maxY, 1);
       }
+      return new SelectLevel(this.maxX, this.maxY, 1);
     } else if (this.levelState === 'Restart') {
       return new Level3(this.maxX, this.maxY);
     }


### PR DESCRIPTION
Returning to the level select screen after ending a level accidentally relied on you not having completed that level before